### PR TITLE
Fix pasting non-html text

### DIFF
--- a/dist/draftail.cjs.js
+++ b/dist/draftail.cjs.js
@@ -1715,7 +1715,7 @@ var DraftailEditor = function (_Component) {
         key: 'handlePastedText',
         value: function handlePastedText(text, html, editorState) {
             var editorKey = this.editorRef.getEditorKey();
-            var isEditor = html.includes('data-editor');
+            var isEditor = html && html.includes('data-editor');
             var htmlKey = isEditor ? /data-editor="(\w+)"/.exec(html)[1] : '';
 
             if (!htmlKey || htmlKey === editorKey || !window.editorRefs[htmlKey]) {

--- a/dist/draftail.esm.js
+++ b/dist/draftail.esm.js
@@ -1708,7 +1708,7 @@ var DraftailEditor = function (_Component) {
         key: 'handlePastedText',
         value: function handlePastedText(text, html, editorState) {
             var editorKey = this.editorRef.getEditorKey();
-            var isEditor = html.includes('data-editor');
+            var isEditor = html && html.includes('data-editor');
             var htmlKey = isEditor ? /data-editor="(\w+)"/.exec(html)[1] : '';
 
             if (!htmlKey || htmlKey === editorKey || !window.editorRefs[htmlKey]) {

--- a/lib/components/DraftailEditor.js
+++ b/lib/components/DraftailEditor.js
@@ -318,7 +318,7 @@ class DraftailEditor extends Component {
 
     handlePastedText(text, html, editorState) {
         const editorKey = this.editorRef.getEditorKey();
-        const isEditor = html.includes('data-editor');
+        const isEditor = html && html.includes('data-editor');
         const htmlKey = isEditor ? /data-editor="(\w+)"/.exec(html)[1] : '';
 
         if (!htmlKey || htmlKey === editorKey || !window.editorRefs[htmlKey]) {


### PR DESCRIPTION
When you paste plain text (for example, copying from a terminal or a simple text editor) the `html` value is undefined so calling `html.includes` throws an error.